### PR TITLE
Update obsolete attribute by a CSS property

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,7 +75,7 @@
                       v-model="product.stockUnits"
                     />
                   </td>
-                  <td align="center">
+                  <td style="text-align:center">
                     <button class="button" @click="updateProduct(index)">
                       Update
                     </button>


### PR DESCRIPTION
The "align" HTML attribute is obsolete.
Changed by "text-align" CSS property for HTML elements.