### PR TITLE
Added commands to create a database and container in the create_database script

### DIFF
--- a/DB_SETUP/CREATE_DATABASE.sh
+++ b/DB_SETUP/CREATE_DATABASE.sh
@@ -11,3 +11,9 @@ groupName=$(az group list --query "[0].name" -o tsv)
 echo "Creating Cosmos DB database $accountName in Resource Group $groupName..."
 echo "This can take up to 10 minutes. Feel free to continue with the Learn Module."
 az cosmosdb create -n $accountName -g $groupName -o none
+
+echo "Creating database $databaseName in Cosmos DB account $accountName..."
+az cosmosdb sql database create -a $accountName -g $groupName -n $databaseName -o none
+
+echo "Creating container $containerName in database $databaseName..."
+az cosmosdb sql container create -a $accountName -g $groupName -d $databaseName -n $containerName -p "/id" -o none


### PR DESCRIPTION
Description: The CREATE_DATABASE.sh script does not automatically create the database and container.
Updated from:
![image](https://github.com/MicrosoftDocs/mslearn-build-api-azure-functions/assets/40116776/6e7ba20b-f85e-4b87-a442-6f29b6058673)

To:
![image](https://github.com/MicrosoftDocs/mslearn-build-api-azure-functions/assets/40116776/2e9769f3-66aa-4348-84ef-c85e0a0cb43d)

Output:
![image](https://github.com/MicrosoftDocs/mslearn-build-api-azure-functions/assets/40116776/71ff6a4b-e0ec-451f-abb8-59193503919e)

